### PR TITLE
Feature/custom errors

### DIFF
--- a/rest/response_test.go
+++ b/rest/response_test.go
@@ -6,6 +6,29 @@ import (
 	"github.com/ant0ine/go-json-rest/rest/test"
 )
 
+func CustomError(r *Request, error string, code int) interface{} {
+	// r = nil when using test requests
+	var header string
+	switch code {
+	case 400:
+		header = "Bad Input"
+		break
+	case 404:
+		header = "Not Found"
+		break
+	default:
+		header = "API Error"
+	}
+
+	return map[string]interface{}{
+		"error": map[string]interface{}{
+			"header":  header,
+			"code":    code,
+			"message": error,
+		},
+	}
+}
+
 func TestResponseNotIndent(t *testing.T) {
 
 	writer := responseWriter{
@@ -24,7 +47,7 @@ func TestResponseNotIndent(t *testing.T) {
 	}
 }
 
-// The following tests could instantiate only the reponseWriter,
+// The following tests could instantiate only the responseWriter,
 // but using the Api object allows to use the rest/test utilities,
 // and make the tests easier to write.
 
@@ -54,6 +77,24 @@ func TestErrorResponse(t *testing.T) {
 	recorded.BodyIs("{\"Error\":\"test\"}")
 }
 
+func TestCustomErrorResponse(t *testing.T) {
+
+	api := NewApi()
+	ErrorFunc = CustomError
+
+	api.SetApp(AppSimple(func(w ResponseWriter, r *Request) {
+		Error(w, "test", 500)
+	}))
+
+	recorded := test.RunRequest(t, api.MakeHandler(), test.MakeSimpleRequest("GET", "http://localhost/", nil))
+	recorded.CodeIs(500)
+	recorded.ContentTypeIsJson()
+	recorded.BodyIs(`{"error":{"code":500,"header":"API Error","message":"test"}}`)
+
+	// reset the package variable to not effect other tests
+	ErrorFunc = nil
+}
+
 func TestNotFoundResponse(t *testing.T) {
 
 	api := NewApi()
@@ -65,4 +106,22 @@ func TestNotFoundResponse(t *testing.T) {
 	recorded.CodeIs(404)
 	recorded.ContentTypeIsJson()
 	recorded.BodyIs("{\"Error\":\"Resource not found\"}")
+}
+
+func TestCustomNotFoundResponse(t *testing.T) {
+
+	api := NewApi()
+	ErrorFunc = CustomError
+
+	api.SetApp(AppSimple(func(w ResponseWriter, r *Request) {
+		NotFound(w, r)
+	}))
+
+	recorded := test.RunRequest(t, api.MakeHandler(), test.MakeSimpleRequest("GET", "http://localhost/", nil))
+	recorded.CodeIs(404)
+	recorded.ContentTypeIsJson()
+	recorded.BodyIs(`{"error":{"code":404,"header":"Not Found","message":"Resource not found"}}`)
+
+	// reset the package variable to not effect other tests
+	ErrorFunc = nil
 }


### PR DESCRIPTION
Add the ability to explicitly define error responses. Created with the intent to be backwards compatible.

https://github.com/ant0ine/go-json-rest/issues/193