### PR TITLE
Store body when decoding from JSON

### DIFF
--- a/rest/request.go
+++ b/rest/request.go
@@ -41,6 +41,7 @@ func (r *Request) DecodeJsonPayload(v interface{}) error {
 		return ErrJsonPayloadEmpty
 	}
 	err = json.Unmarshal(content, v)
+	r.Env["content"] = v
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
recover_middleware is unable to recovery the request body when it has already be read. Store the body in r.Env[content] for logging and error handling